### PR TITLE
Task/zan 130

### DIFF
--- a/app/src/androidTest/java/io/reist/sandbox/repos/ReposUiTest.java
+++ b/app/src/androidTest/java/io/reist/sandbox/repos/ReposUiTest.java
@@ -23,6 +23,8 @@ package io.reist.sandbox.repos;
 import android.support.test.espresso.contrib.DrawerActions;
 import android.support.test.espresso.contrib.RecyclerViewActions;
 import android.support.test.runner.AndroidJUnit4;
+import android.text.TextUtils;
+import android.widget.TextView;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -33,6 +35,7 @@ import java.util.Random;
 import io.reist.sandbox.R;
 import io.reist.sandbox.app.view.MainActivity;
 import io.reist.sandbox.core.ActivityInstrumentationTestCase;
+import io.reist.sandbox.core.TestUtils;
 
 import static android.support.test.espresso.Espresso.onView;
 import static android.support.test.espresso.action.ViewActions.clearText;
@@ -41,6 +44,7 @@ import static android.support.test.espresso.action.ViewActions.typeText;
 import static android.support.test.espresso.assertion.ViewAssertions.matches;
 import static android.support.test.espresso.matcher.ViewMatchers.isDescendantOfA;
 import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static android.support.test.espresso.matcher.ViewMatchers.isRoot;
 import static android.support.test.espresso.matcher.ViewMatchers.withContentDescription;
 import static android.support.test.espresso.matcher.ViewMatchers.withId;
 import static android.support.test.espresso.matcher.ViewMatchers.withText;
@@ -66,18 +70,24 @@ public class ReposUiTest extends ActivityInstrumentationTestCase<MainActivity> {
 
     @Test
     public void testRepo() throws InterruptedException {
+
         onView(withId(R.id.drawer_layout))
                 .perform(DrawerActions.open());
 
         onView(allOf(isDescendantOfA(withId(R.id.nav_view)), withText(R.string.menu_repos)))
                 .perform(click());
 
-        Thread.sleep(1000);
+        onView(isRoot())
+                .perform(TestUtils.waitId(R.id.daggertest_repo_item_text_view, TestUtils.ACTION_TIMEOUT));
 
         onView(withId(R.id.daggertest_repo_recycler_view))
                 .perform(RecyclerViewActions.actionOnItemAtPosition(0, click()));
 
-        Thread.sleep(1000);
+        onView(isRoot())
+                .perform(TestUtils.waitId(R.id.repo_name, TestUtils.ACTION_TIMEOUT, v -> {
+                    final CharSequence text = ((TextView) v).getText();
+                    return !TextUtils.isEmpty(text);
+                }));
 
         String generatedRepoName = generateRepoName();
 
@@ -90,12 +100,15 @@ public class ReposUiTest extends ActivityInstrumentationTestCase<MainActivity> {
         onView(withContentDescription(android.support.v7.appcompat.R.string.abc_action_bar_up_description))
                 .perform(click());
 
-        Thread.sleep(1000);
+        onView(isRoot())
+                .perform(TestUtils.wait(withText(generatedRepoName), TestUtils.ACTION_TIMEOUT));
 
         onView(withText(generatedRepoName)).check(matches(isDisplayed()));
+
     }
 
     public static String generateRepoName() {
         return "cracky" + (new Random().nextInt(10000));
     }
+
 }

--- a/app/src/androidTest/java/io/reist/sandbox/users/UsersUiTest.java
+++ b/app/src/androidTest/java/io/reist/sandbox/users/UsersUiTest.java
@@ -29,8 +29,6 @@ import android.support.v7.widget.RecyclerView;
 import android.util.Log;
 import android.widget.TextView;
 
-import junit.framework.Assert;
-
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -38,14 +36,15 @@ import org.junit.runner.RunWith;
 import io.reist.sandbox.R;
 import io.reist.sandbox.app.view.MainActivity;
 import io.reist.sandbox.core.ActivityInstrumentationTestCase;
+import io.reist.sandbox.core.TestUtils;
 
 import static android.support.test.espresso.Espresso.onView;
 import static android.support.test.espresso.action.ViewActions.click;
 import static android.support.test.espresso.matcher.ViewMatchers.isDescendantOfA;
+import static android.support.test.espresso.matcher.ViewMatchers.isRoot;
 import static android.support.test.espresso.matcher.ViewMatchers.withId;
 import static android.support.test.espresso.matcher.ViewMatchers.withText;
 import static io.reist.sandbox.core.TestUtils.clickOnId;
-import static io.reist.sandbox.core.TestUtils.waitForMs;
 import static org.hamcrest.Matchers.allOf;
 
 /**
@@ -53,11 +52,6 @@ import static org.hamcrest.Matchers.allOf;
  */
 @RunWith(AndroidJUnit4.class)
 public class UsersUiTest extends ActivityInstrumentationTestCase<MainActivity> {
-
-    /**
-     * Should take into consideration delays during network operations
-     */
-    public static final int ACTION_TIMEOUT = 5000;
 
     MainActivity mMainActivity;
 
@@ -82,13 +76,15 @@ public class UsersUiTest extends ActivityInstrumentationTestCase<MainActivity> {
         onView(allOf(isDescendantOfA(withId(R.id.nav_view)), withText(R.string.menu_users)))
                 .perform(click());
 
-        waitForMs(ACTION_TIMEOUT);
+        onView(isRoot())
+                .perform(TestUtils.waitId(R.id.name, TestUtils.ACTION_TIMEOUT));
 
         // click on user
         onView(withId(R.id.recycler))
                 .perform(RecyclerViewActions.actionOnItemAtPosition(0, click()));
 
-        waitForMs(ACTION_TIMEOUT);
+        onView(isRoot())
+                .perform(TestUtils.waitId(R.id.like, TestUtils.ACTION_TIMEOUT));
 
         // is first repo liked?
         boolean isLiked = isRepoLiked(R.id.recycler, 0);
@@ -99,23 +95,20 @@ public class UsersUiTest extends ActivityInstrumentationTestCase<MainActivity> {
         onView(withId(R.id.recycler))
                 .perform(RecyclerViewActions.actionOnItemAtPosition(0, clickOnId(R.id.like)));
 
-        waitForMs(ACTION_TIMEOUT);
-
-        // check if like status changed
-        Assert.assertEquals(!isLiked, isRepoLiked(R.id.recycler, 0));
+        onView(isRoot())
+                .perform(TestUtils.waitId(R.id.like, TestUtils.ACTION_TIMEOUT, v -> !isLiked == isRepoLiked(R.id.recycler, 0)));
 
         // click on like button (should be an opposite of first button state)
         onView(withId(R.id.recycler))
                 .perform(RecyclerViewActions.actionOnItemAtPosition(0, clickOnId(R.id.like)));
 
-        waitForMs(ACTION_TIMEOUT);
-
-        // check if like status reverted
-        Assert.assertEquals(isLiked, isRepoLiked(R.id.recycler, 0));
+        onView(isRoot())
+                .perform(TestUtils.waitId(R.id.like, TestUtils.ACTION_TIMEOUT, v -> isLiked == isRepoLiked(R.id.recycler, 0)));
 
     }
 
     boolean isRepoLiked(@IdRes int recyclerViewId, int position) {
+
         Activity activity = mMainActivity;
 
         TextView like = (TextView) ((RecyclerView) activity.findViewById(recyclerViewId))
@@ -124,6 +117,7 @@ public class UsersUiTest extends ActivityInstrumentationTestCase<MainActivity> {
                 .findViewById(R.id.like);
 
         final String label = like.getText().toString();
+
         if (label.equalsIgnoreCase(activity.getString(R.string.repo_button_unlike))) {
             return true;
         } else if (label.equalsIgnoreCase(activity.getString(R.string.repo_button_like))) {
@@ -132,5 +126,7 @@ public class UsersUiTest extends ActivityInstrumentationTestCase<MainActivity> {
             fail("Like button label: " + label);
             return false;
         }
+
     }
+
 }

--- a/app/src/main/java/io/reist/sandbox/app/view/BaseFragment.java
+++ b/app/src/main/java/io/reist/sandbox/app/view/BaseFragment.java
@@ -43,10 +43,8 @@ public abstract class BaseFragment<P extends VisumPresenter> extends VisumFragme
         }
     }
 
-
     public interface FragmentController {
-
         void showFragment(VisumFragment fragment, boolean remove);
-
     }
+
 }

--- a/app/src/main/java/io/reist/sandbox/repos/view/RepoListFragment.java
+++ b/app/src/main/java/io/reist/sandbox/repos/view/RepoListFragment.java
@@ -93,7 +93,6 @@ public class RepoListFragment extends BaseFragment<RepoListPresenter> implements
         return presenter;
     }
 
-
     @Override
     public void showLoader(boolean show) {
         loaderView.showLoading(show);


### PR DESCRIPTION
Related to https://dreams.atlassian.net/browse/ZAN-130
- replaced timed waits with correct "wait for" methods -> ui test performance is boosted on decent hardware
- increased timeout operation (timeout of 5 secs is not enough for slow emulation)

Requires https://github.com/ragnor-rs/visum/pull/21
